### PR TITLE
Wrong path to heartbeat-gui

### DIFF
--- a/mgmt/client/mgmtcmd.py.in
+++ b/mgmt/client/mgmtcmd.py.in
@@ -24,7 +24,7 @@ Copyright (C) 2005 International Business Machines
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import sys
-sys.path.append("@HA_LIBHBDIR@/heartbeat-gui")
+sys.path.append("@LIBDIR@/heartbeat-gui")
 sys.path.append("@HA_DATADIR@/heartbeat-gui")
 
 from pymgmt import *


### PR DESCRIPTION
I think @HA_LIBHBDIR@ should be @LIBDIR@ just like in haclient.py.in.

Not sure if you would want the change the order of the data and library path as well to make it the same as in haclient.py.in
